### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 This provides an efficent way to build and manipulate IPLD DAGs as JSON. This is accomplished by only producing merkle roots when `flush`ing the DAG. If any object has a "/" property, its value will be replaced with the merkle hash of that value when flushed. This allows you to build object anyway you like. 
 
+# LEAD MAINTAINER
+
+[wanderer](https://github.com/wanderer)
+
 # INSTALL
 `npm install ipld-graph-builder`
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ipld-graph-builder",
   "version": "1.3.8",
   "description": "a merkle trie implemention that if focused on being generic and fast",
+  "leadMaintainer": "mjbecze <mjbecze@gmail.com>",
   "main": "index.js",
   "scripts": {
     "coveralls": "npm run coverage && nyc report --reporter=text-lcov | coveralls",
@@ -15,7 +16,6 @@
     "dag",
     "ipfs"
   ],
-  "author": "mjbecze <mjbecze@gmail.com>",
   "license": "MPL-2.0",
   "dependencies": {
     "assert": "^1.4.1",


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md